### PR TITLE
fixed typo 'linstrings' -> 'linestrings'

### DIFF
--- a/space/ring.go
+++ b/space/ring.go
@@ -20,12 +20,12 @@ func (r Ring) Dimensions() int {
 	return 2
 }
 
-// Nums num of linstrings
+// Nums num of linestrings
 func (r Ring) Nums() int {
 	return 1
 }
 
-// IsCollection returns true if the Geometry is  collection.
+// IsCollection returns true if the Geometry is collection.
 func (r Ring) IsCollection() bool {
 	return false
 }


### PR DESCRIPTION
Hello there👋

I have made a pull request to fix a small typo in the documentation. The word 'linstrings' was misspelled, and I have corrected it to 'linestrings'.