### PR TITLE
107: Fill cluster.PointList and cluster.Center in DBScan()

### DIFF
--- a/clusters/dbscan/dbscan.go
+++ b/clusters/dbscan/dbscan.go
@@ -37,7 +37,8 @@ func DBScan(points clusters.PointList, eps float64, minPoints int) (clusterArray
 		if len(neighborPts) < minPoints {
 			noise = append(noise, i)
 		} else {
-			cluster := clusters.Cluster{C: C, Points: []int{i}}
+			// init cluster with center point
+			cluster := clusters.Cluster{C: C, Points: []int{i}, PointList: []space.Point{points[i]}}
 			members[i] = true
 			C++
 			// expandCluster goes here inline
@@ -63,9 +64,11 @@ func DBScan(points clusters.PointList, eps float64, minPoints int) (clusterArray
 
 				if !members[k] {
 					cluster.Points = append(cluster.Points, k)
+					cluster.PointList = append(cluster.PointList, points[k])
 					members[k] = true
 				}
 			}
+			cluster.Recenter()
 			clusterArray = append(clusterArray, cluster)
 		}
 	}


### PR DESCRIPTION
Fill the cluster object's fields `PointList` and `Center` during the run of `DBScan()`.
Add appropriate checks to unit-test.

closes #107