### PR TITLE
Fix: append all slice data when range for it

### DIFF
--- a/algorithm/overlay/chain/intersection_interior.go
+++ b/algorithm/overlay/chain/intersection_interior.go
@@ -31,7 +31,7 @@ func (ii *IntersectionInterior) ProcessIntersections(
 			if ip.IsCollinear {
 				continue
 			}
-			ii.Intersections = append(ii.Intersections, ips...)
+			ii.Intersections = append(ii.Intersections, ip)
 		}
 	}
 }


### PR DESCRIPTION
## TLDR: FIx a bug

I am writing a linter called [sundrylint](https://github.com/alingse/sundrylint) to address some real-world bugs that I discovered during my work.

When we range over a slice and call the append function within the loop body, we are not appending all elements, but only the ones that we specifically iterate over during the range operation.

```
for _, n := range ns {
   rs = append(rs, n)       # this is mostly wanted
   rs = append(rs, ns...)   # this is wrong
}
```
I read the code in here and I think it was just want to append the not IsCollinear ip